### PR TITLE
[FEATURE] - Add support for ES6 module system, add global configuration helper.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,6 +5,13 @@
     },
     "production": {
       "presets": ["es2015", "react"]
+    },
+    "test":{
+      "presets": ["react"],
+      "plugins": [
+        "transform-es2015-modules-commonjs",
+        "add-module-exports"
+      ]
     }
   }
 }

--- a/mocha.opts
+++ b/mocha.opts
@@ -1,0 +1,3 @@
+--require babel-register
+--require test/helpers/global
+--R list

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "mocha --require babel-register",
     "unit:karma": "karma start karma.conf.js --single-run",
     "unit:karma-babel": "karma start karma-babel.conf.js --single-run",
-    "unit:just-mocha": "mocha test/unit.spec.js",
+    "unit:just-mocha":  "NODE_ENV=test mocha --opts ./mocha.opts",
     "unit:mocha-babel": "mocha test/unit.spec.js --require babel-register",
     "unit:mocha-jsdom": "mocha test/unit-jsdom.spec.js --require babel-register"
   },
@@ -30,8 +30,13 @@
   },
   "homepage": "https://github.com/giltayar/ode-to-node#readme",
   "devDependencies": {
+    "babel-register": "^6.16.3",
+    "babel-loader": "^6.2.0",
+    "babel-plugin-add-module-exports": "^0.2.1",
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.14.0",
     "babel-plugin-transform-react-jsx": "^6.8.0",
-    "babel-register": "^6.14.0",
+    "babel-preset-react": "^6.3.13",
+    "babel-plugin-react-transform": "^2.0.0-beta1",
     "chai": "^3.5.0",
     "enzyme": "^2.4.1",
     "jquery-slim": "^3.0.0",

--- a/test/helpers/global.js
+++ b/test/helpers/global.js
@@ -1,0 +1,29 @@
+(function(){
+    
+    'use strict';
+
+    setGlobals();
+    setReactGlobals();
+
+    function setGlobals() {
+        const jsdom = require('jsdom');
+        const {describe, it} = require('mocha');
+        const jQuery = require('jquery-slim');
+        const { expect } = require('chai');
+
+        global.document = jsdom.jsdom('<div id="root"></div>');
+        global.window = document.defaultView;
+        global.navigator = window.navigator;
+        global.dispatchEvent = window.dispatchEvent;
+        global.$ = jQuery(window);
+        global.describe = describe;
+        global.it = it;
+        global.expect = expect;
+    }
+    
+    function setReactGlobals() {
+        global.reactDOM =  require('react-dom');
+        global.React = require('react');
+    }
+
+}());

--- a/test/unit-jsdom.spec.js
+++ b/test/unit-jsdom.spec.js
@@ -1,27 +1,13 @@
-const {describe, it} = require('mocha')
-const {expect} = require('chai')
-const jsdom = require('jsdom')
-const jQuery = require('jquery-slim')
-
 describe('Counter (jsdom)', function() {
   let Counter
-  let React
-  let reactDOM
+
 
   beforeEach(function() {
-    global.document = jsdom.jsdom('<div id="mount-point">Hello, World<div>')
-    global.window = document.defaultView
-    global.navigator = window.navigator
-
-    React = require('react')
-    reactDOM = require('react-dom')
     Counter = require('../src/Counter')
   })
 
   it('should include an <a> with a - sign', function() {
-    reactDOM.render(<Counter/>, document.getElementById('mount-point'))
-
-    const $ = jQuery(window)
+    reactDOM.render(<Counter/>, document.getElementById('root'))
     expect($('a')).to.have.length(2)
     expect($('a:eq(0)').text()).to.equal('-')
 


### PR DESCRIPTION
Hi Gil! 
Inspired by your presentation at the React 2016 conference, I dig into it and add two features -  
- Still Running the tests with Node 6, but only transpiling ES6 `import` & `export` (until it will be supported by Node).
  This way, we can still use ES6 module system in our source code.
- Added a global helper in order to follow the DRY principle.

run command - `npm run unit:just-mocha test/unit-jsdom.spec.js`
